### PR TITLE
Hide the implementation details of the Board class

### DIFF
--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -23,24 +23,14 @@ public class Board {
         return SIZE;
     }
 
-    public String[][] getContents() {
-        String[][] copy = new String[SIZE][SIZE];
+    public Board getCopy() {
+        Board copy = new Board(SIZE);
 
-        for(int row = 0; row < SIZE; row++) {
-            for (int col = 0; col < SIZE; col++) {
-                copy[row][col] = board[row][col];
-            }
+        for(int index = 1; index <= SIZE*SIZE; index++) {
+            copy.setCell(index, this.getCell(index));
         }
 
         return copy;
-    }
-
-    public void setContents(String[][] contents) {
-        for(int row = 0; row < SIZE; row++) {
-            for (int col = 0; col < SIZE; col++) {
-                board[row][col] = contents[row][col];
-            }
-        }
     }
 
     public void reset() {

--- a/src/main/java/RobotTurn.java
+++ b/src/main/java/RobotTurn.java
@@ -58,8 +58,7 @@ public class RobotTurn {
     }
 
     private void placeMark(Board currentBoard, int tempIndex, String currentPlayer) {
-        tempBoard = new Board(size);
-        tempBoard.setContents(currentBoard.getContents());
+        tempBoard = currentBoard.getCopy();
         tempBoard.setCell(tempIndex, currentPlayer);
     }
 

--- a/src/main/java/UserInterface.java
+++ b/src/main/java/UserInterface.java
@@ -26,20 +26,19 @@ public class UserInterface {
     }
 
     public void printBoard(Board board) {
-        int cellIndex = 0;
 
-        for (String[] row : board.getContents()) {
-            for (String cell : row) {
-                cellIndex++;
-                print(formatCell(cellIndex, cell));
+        int size = board.getSize();
+        for (int index = 1; index<= size * size; index++) {
+            print(formatCell(index, board.getCell(index)));
+
+            if (index % size == 0) {
+                print("\n");
             }
-
-            print("\n");
         }
     }
 
-    private String formatCell(int cellIndex, String cell) {
-        return (cell.equals("")) ? cellIndex + " " : cell + " ";
+    private String formatCell(int index, String cell) {
+        return (cell.equals("")) ? index + " " : cell + " ";
     }
 
     public void printWelcomeMessage() {

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -1,7 +1,6 @@
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -19,19 +18,10 @@ public class BoardTest {
     }
 
     @Test
-    public void getsTheContentsOfTheBoard() {
-        Board expected = setAllCellsTo("");
-        expected.setCell(1, "hi");
+    public void getsACopyOfTheBoard() {
         board.setCell(1, "hi");
-        assertTrue( Arrays.deepEquals(expected.getContents(), board.getContents()) );
-    }
-
-    @Test
-    public void setsTheContentsOfTheBoard() {
-        board = setAllCellsTo("");
-        Board expected = setAllCellsTo("hi");
-        board.setContents(expected.getContents());
-        assertTrue(Arrays.deepEquals(expected.getContents(), board.getContents()));
+        Board copy = board.getCopy();
+        assertEquals( getContentsAsString(board), getContentsAsString(copy) );
     }
 
     @Test
@@ -39,7 +29,7 @@ public class BoardTest {
         board.setCell(1, "hi");
         board.reset();
         Board expected = setAllCellsTo("");
-        assertTrue( Arrays.deepEquals(expected.getContents(), board.getContents()) );
+        assertEquals(getContentsAsString(expected), getContentsAsString(board));
     }
 
     @Test
@@ -93,5 +83,13 @@ public class BoardTest {
         }
 
         return expected;
+    }
+
+    private String getContentsAsString(Board board) {
+        String boardContents = "";
+        for (int index = 1; index <= size*size; index++) {
+            boardContents = board.getCell(index);
+        }
+        return boardContents;
     }
 }

--- a/src/test/java/GameTest.java
+++ b/src/test/java/GameTest.java
@@ -47,11 +47,11 @@ public class GameTest {
 
     @Test
     public void turnUpdatesTheBoardInEveryTurn() {
-        String[][] old = game.getBoard().getContents();
+        Board old = game.getBoard().getCopy();
         spy.setInput("1");
         playTurns(1);
 
-        assertFalse(Arrays.deepEquals(old, game.getBoard().getContents()));
+        assertNotEquals(old, game.getBoard());
         assertEquals("X", game.getBoard().getCell(1));
     }
 


### PR DESCRIPTION
I was exposing the fact that my Board class uses a two-dimensional String array as the structure to save the marks, so I hid it by returning a Board object instead.

This commit needed a lot of things to be changed at the same time, so there are a lot of files affected; in particular, those that use the Board.
- Get contents now returns a copy of the board as a Board object instead of a String[][] structure.
- There is no need for set contents in the Board class.
- Updates the mark placing in the robot turn when calling minimax and making a copy of the board.
- Updates the board printing method in the user interface.
- Updates tests and add a helper method to the board test class.
