### PR TITLE
Player creator

### DIFF
--- a/src/main/java/com/mael/ttt/Board.java
+++ b/src/main/java/com/mael/ttt/Board.java
@@ -1,6 +1,7 @@
 package com.mael.ttt;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class Board {
 
@@ -42,8 +43,8 @@ public class Board {
         }
     }
 
-    public ArrayList<Integer> getEmptyCellIndexes() {
-        ArrayList<Integer> empties = new ArrayList();
+    public List<Integer> getEmptyCellIndexes() {
+        List<Integer> empties = new ArrayList();
 
         for (int index = 1; index <= SIZE*SIZE; index++) {
             if (getCell(index).equals("")) {

--- a/src/main/java/com/mael/ttt/Game.java
+++ b/src/main/java/com/mael/ttt/Game.java
@@ -14,7 +14,7 @@ public class Game {
         this.lastPlayer    = opponent;
     }
 
-    public void start() {
+    public void play() {
         while (turn.canBePlayed()) {
             turn.placeMark(getCurrentPlayer());
             swapPlayers();

--- a/src/main/java/com/mael/ttt/GameSetup.java
+++ b/src/main/java/com/mael/ttt/GameSetup.java
@@ -2,11 +2,8 @@ package com.mael.ttt;
 
 import com.mael.ttt.players.*;
 import com.mael.ttt.ui.Menu;
+import com.mael.ttt.ui.MenuOption;
 import com.mael.ttt.ui.UserInterface;
-
-import static com.mael.ttt.Mark.*;
-import static com.mael.ttt.players.PlayerType.*;
-import static com.mael.ttt.ui.MenuOption.idToOption;
 
 public class GameSetup {
     private Board board;
@@ -22,7 +19,7 @@ public class GameSetup {
     public void playGame() {
         do {
             setUp();
-            String option = getMenuOption();
+            MenuOption option = getMenuOption();
             Game game     = new Game(new Turn(board, checker, gameUI), createPlayer(option), createOpponent(option));
             game.start();
         } while (gameUI.replay().equals("y"));
@@ -33,32 +30,15 @@ public class GameSetup {
         gameUI.printWelcomeMessage();
     }
 
-    private String getMenuOption() {
+    private MenuOption getMenuOption() {
         return new Menu(gameUI).getUserOption();
     }
 
-    private Player createPlayer(String option) {
-        return createPlayerOfType(getPlayerType(option), PLAYER);
+    private Player createPlayer(MenuOption option) {
+        return new PlayerCreator(gameUI).createPlayer(option);
     }
 
-    private Player createOpponent(String option) {
-        return createPlayerOfType(getOpponentType(option), OPPONENT);
-    }
-
-    private PlayerType getPlayerType(String option) {
-        return idToOption(option).getPlayerType();
-    }
-
-    private PlayerType getOpponentType(String option) {
-        return idToOption(option).getOpponentType();
-    }
-
-    public Player createPlayerOfType(PlayerType playerType, Mark mark) {
-        if (playerType == ROBOT) {
-            return new RobotPlayer(gameUI, mark);
-        } else if (playerType == ALIEN) {
-            return new AlienPlayer(gameUI, mark);
-        }
-        return new HumanPlayer(gameUI, mark);
+    private Player createOpponent(MenuOption option) {
+        return new PlayerCreator(gameUI).createOpponent(option);
     }
 }

--- a/src/main/java/com/mael/ttt/GameSetup.java
+++ b/src/main/java/com/mael/ttt/GameSetup.java
@@ -20,8 +20,8 @@ public class GameSetup {
         do {
             setUp();
             MenuOption option = getMenuOption();
-            Game game     = new Game(new Turn(board, checker, gameUI), createPlayer(option), createOpponent(option));
-            game.start();
+            Game game         = new Game(new Turn(board, checker, gameUI), createPlayer(option), createOpponent(option));
+            game.play();
         } while (gameUI.replay().equals("y"));
     }
 

--- a/src/main/java/com/mael/ttt/Mark.java
+++ b/src/main/java/com/mael/ttt/Mark.java
@@ -14,8 +14,4 @@ public enum Mark {
     public String getString() {
         return mark;
     }
-
-    public Mark swapMark() {
-        return (this == PLAYER) ? OPPONENT : PLAYER;
-    }
 }

--- a/src/main/java/com/mael/ttt/players/AlienPlayer.java
+++ b/src/main/java/com/mael/ttt/players/AlienPlayer.java
@@ -7,8 +7,6 @@ import com.mael.ttt.ui.UserInterface;
 import java.util.List;
 import java.util.Random;
 
-import static com.mael.ttt.players.PlayerType.ALIEN;
-
 public class AlienPlayer implements Player {
     private final UserInterface gameUI;
     private final Mark mark;
@@ -20,9 +18,8 @@ public class AlienPlayer implements Player {
 
     public int getMove(Board board) {
         gameUI.printAlienPrompt();
-
-        List<Integer> empties = board.getEmptyCellIndexes();
-        return empties.get(new Random().nextInt(empties.size()));
+        List<Integer> emptyCellIndexes = board.getEmptyCellIndexes();
+        return emptyCellIndexes.get(new Random().nextInt(emptyCellIndexes.size()));
     }
 
     public Mark getMark() {

--- a/src/main/java/com/mael/ttt/players/HumanPlayer.java
+++ b/src/main/java/com/mael/ttt/players/HumanPlayer.java
@@ -4,8 +4,6 @@ import com.mael.ttt.Board;
 import com.mael.ttt.Mark;
 import com.mael.ttt.ui.UserInterface;
 
-import static com.mael.ttt.players.PlayerType.HUMAN;
-
 public class HumanPlayer implements Player {
 
     private UserInterface gameUI;

--- a/src/main/java/com/mael/ttt/players/PlayerCreator.java
+++ b/src/main/java/com/mael/ttt/players/PlayerCreator.java
@@ -1,0 +1,34 @@
+package com.mael.ttt.players;
+
+import com.mael.ttt.Mark;
+import com.mael.ttt.ui.MenuOption;
+import com.mael.ttt.ui.UserInterface;
+
+import static com.mael.ttt.Mark.*;
+import static com.mael.ttt.players.PlayerType.*;
+
+public class PlayerCreator {
+
+    private UserInterface gameUI;
+
+    public PlayerCreator(UserInterface gameUI) {
+        this.gameUI = gameUI;
+    }
+
+    public Player createPlayer(MenuOption option) {
+        return createPlayerOfType(option.getPlayerType(), PLAYER);
+    }
+
+    public Player createOpponent(MenuOption option) {
+        return createPlayerOfType(option.getOpponentType(), OPPONENT);
+    }
+
+    private Player createPlayerOfType(PlayerType playerType, Mark mark) {
+        if (playerType == ROBOT) {
+            return new RobotPlayer(gameUI, mark);
+        } else if (playerType == ALIEN) {
+            return new AlienPlayer(gameUI, mark);
+        }
+        return new HumanPlayer(gameUI, mark);
+    }
+}

--- a/src/main/java/com/mael/ttt/players/RobotPlayer.java
+++ b/src/main/java/com/mael/ttt/players/RobotPlayer.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import static com.mael.ttt.Mark.OPPONENT;
 import static com.mael.ttt.Mark.PLAYER;
-import static com.mael.ttt.players.PlayerType.ROBOT;
 
 public class RobotPlayer implements Player {
 
@@ -21,7 +20,7 @@ public class RobotPlayer implements Player {
     public RobotPlayer(UserInterface ui, Mark mark) {
         this.gameUI      = ui;
         this.mark        = mark;
-        playerToOptimize = this.mark.getString();
+        playerToOptimize = mark.getString();
     }
 
     public int getMove(Board board) {

--- a/src/main/java/com/mael/ttt/ui/Menu.java
+++ b/src/main/java/com/mael/ttt/ui/Menu.java
@@ -13,13 +13,13 @@ public class Menu {
         initializeOptions();
     }
 
-    public String getUserOption() {
+    public MenuOption getUserOption() {
         String option = "";
         while (isInvalidOption(option)) {
             gameUI.printMenuPrompt();
             option = gameUI.getMenuOption(gameUI.formatMenuOptions());
         }
-        return option;
+        return MenuOption.idToOption(option);
     }
 
     private boolean isInvalidOption(String option) {

--- a/src/test/java/com/mael/ttt/GameSetupTest.java
+++ b/src/test/java/com/mael/ttt/GameSetupTest.java
@@ -1,30 +1,27 @@
 package com.mael.ttt;
 
-import com.mael.ttt.players.AlienPlayer;
-import com.mael.ttt.players.HumanPlayer;
-import com.mael.ttt.players.RobotPlayer;
 import com.mael.ttt.ui.SpyConsole;
 import com.mael.ttt.ui.UserInterface;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.mael.ttt.Mark.PLAYER;
-import static com.mael.ttt.players.PlayerType.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class GameSetupTest {
 
     private SpyConsole spy;
     private GameSetup gameSetup;
     private UserInterface gameUI;
+    private Board board;
+    private int size;
 
     @Before
     public void setUp() {
-        int size  = 3;
+        size = 3;
+        board     = new Board(size);
         spy       = new SpyConsole();
         gameUI    = new UserInterface(spy);
-        gameSetup = new GameSetup(new Board(size), gameUI);
+        gameSetup = new GameSetup(board, gameUI);
     }
 
     @Test
@@ -46,20 +43,5 @@ public class GameSetupTest {
                       "n");
         gameSetup.playGame();
         assertEquals(UserInterface.REPLAY, spy.lastPrintedMessage());
-    }
-
-    @Test
-    public void createsAHuman() {
-        assertTrue(gameSetup.createPlayerOfType(HUMAN, PLAYER) instanceof HumanPlayer);
-    }
-
-    @Test
-    public void createsARobot() {
-        assertTrue(gameSetup.createPlayerOfType(ROBOT, PLAYER) instanceof RobotPlayer);
-    }
-
-    @Test
-    public void createsAnAlien() {
-        assertTrue(gameSetup.createPlayerOfType(ALIEN, PLAYER) instanceof AlienPlayer);
     }
 }

--- a/src/test/java/com/mael/ttt/GameSetupTest.java
+++ b/src/test/java/com/mael/ttt/GameSetupTest.java
@@ -9,19 +9,15 @@ import static org.junit.Assert.assertEquals;
 
 public class GameSetupTest {
 
+    private int size;
     private SpyConsole spy;
     private GameSetup gameSetup;
-    private UserInterface gameUI;
-    private Board board;
-    private int size;
 
     @Before
     public void setUp() {
-        size = 3;
-        board     = new Board(size);
+        size      = 3;
         spy       = new SpyConsole();
-        gameUI    = new UserInterface(spy);
-        gameSetup = new GameSetup(board, gameUI);
+        gameSetup = new GameSetup(new Board(size), new UserInterface(spy));
     }
 
     @Test

--- a/src/test/java/com/mael/ttt/GameTest.java
+++ b/src/test/java/com/mael/ttt/GameTest.java
@@ -27,27 +27,25 @@ public class GameTest {
         game = new Game(new Turn(board, new BoardChecker(board), uiSpy),
                 new FakePlayer(PLAYER, 1, 2, 3),
                 new FakePlayer(OPPONENT, 4, 5));
-        game.start();
-        assertTrue(uiSpy.printHasWinnerMessageHasBeenCalled());
+        game.play();
+        assertTrue(uiSpy.printHasWinnerMessageWasCalled());
     }
 
     @Test
     public void endsTheGameIfFull() {
-        UserInterfaceSpy uiSpy = new UserInterfaceSpy();
         game = new Game(new Turn(board, new BoardChecker(board), uiSpy),
                 new FakePlayer(PLAYER, 1, 2, 5, 6, 7),
                 new FakePlayer(OPPONENT, 4, 3, 9, 8));
-        game.start();
-        assertTrue(uiSpy.printIsFullMessageHasBeenCalled());
+        game.play();
+        assertTrue(uiSpy.printIsFullMessageWasCalled());
     }
 
     @Test
-    public void markIsSwappedInEveryTurn() {
-        UserInterfaceSpy uiSpy = new UserInterfaceSpy();
+    public void playerIsSwappedInEveryTurn() {
         game = new Game(new Turn(board, new BoardChecker(board), uiSpy),
                 new FakePlayer(PLAYER, 1, 3, 5, 7),
                 new FakePlayer(OPPONENT, 2, 4, 6));
-        game.start();
+        game.play();
 
         assertEquals(PLAYER.getString(),   board.getCell(1));
         assertEquals(OPPONENT.getString(), board.getCell(2));

--- a/src/test/java/com/mael/ttt/MarkTest.java
+++ b/src/test/java/com/mael/ttt/MarkTest.java
@@ -16,14 +16,4 @@ public class MarkTest {
     public void convertsOpponentMarkToString() {
         assertEquals("O", OPPONENT.getString());
     }
-
-    @Test
-    public void swapsPlayerMark() {
-        assertEquals(OPPONENT, PLAYER.swapMark());
-    }
-
-    @Test
-    public void swapsOpponentMark() {
-        assertEquals(PLAYER, OPPONENT.swapMark());
-    }
 }

--- a/src/test/java/com/mael/ttt/TurnTest.java
+++ b/src/test/java/com/mael/ttt/TurnTest.java
@@ -6,8 +6,7 @@ import com.mael.ttt.ui.UserInterfaceSpy;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.mael.ttt.Mark.OPPONENT;
-import static com.mael.ttt.Mark.PLAYER;
+import static com.mael.ttt.Mark.*;
 import static org.junit.Assert.*;
 
 public class TurnTest {
@@ -30,7 +29,7 @@ public class TurnTest {
     @Test
     public void printsTheBoardInEveryTurn() {
         turn.placeMark(player);
-        assertTrue(uiSpy.printBoardHasBeeCalled());
+        assertTrue(uiSpy.printBoardWasCalled());
     }
 
     @Test
@@ -67,7 +66,7 @@ public class TurnTest {
                                 O,  O, "",
                                "", "", "");
         turn.printResults(PLAYER);
-        assertTrue(uiSpy.printBoardHasBeeCalled());
+        assertTrue(uiSpy.printBoardWasCalled());
     }
 
     @Test
@@ -76,7 +75,7 @@ public class TurnTest {
                                 O,  X,  X,
                                 O,  X,  O);
         turn.printResults(PLAYER);
-        assertTrue(uiSpy.printBoardHasBeeCalled());
+        assertTrue(uiSpy.printBoardWasCalled());
     }
 
     @Test
@@ -85,8 +84,8 @@ public class TurnTest {
                                 O,  O, "",
                                "", "", "");
         turn.printResults(PLAYER);
-        assertTrue(uiSpy.printHasWinnerMessageHasBeenCalled());
-        assertFalse(uiSpy.printIsFullMessageHasBeenCalled());
+        assertTrue(uiSpy.printHasWinnerMessageWasCalled());
+        assertFalse(uiSpy.printIsFullMessageWasCalled());
 
     }
 
@@ -96,8 +95,8 @@ public class TurnTest {
                                 O,  X,  X,
                                 O,  X,  O);
         turn.printResults(PLAYER);
-        assertTrue(uiSpy.printIsFullMessageHasBeenCalled());
-        assertFalse(uiSpy.printHasWinnerMessageHasBeenCalled());
+        assertTrue(uiSpy.printIsFullMessageWasCalled());
+        assertFalse(uiSpy.printHasWinnerMessageWasCalled());
 
     }
 
@@ -107,9 +106,9 @@ public class TurnTest {
                                 O,  O, "",
                                "", "", "");
         turn.printResults(PLAYER);
-        assertTrue(uiSpy.printBoardHasBeeCalled());
-        assertFalse(uiSpy.printHasWinnerMessageHasBeenCalled());
-        assertFalse(uiSpy.printIsFullMessageHasBeenCalled());
+        assertTrue(uiSpy.printBoardWasCalled());
+        assertFalse(uiSpy.printHasWinnerMessageWasCalled());
+        assertFalse(uiSpy.printIsFullMessageWasCalled());
     }
 
     @Test

--- a/src/test/java/com/mael/ttt/players/AlienPlayerTest.java
+++ b/src/test/java/com/mael/ttt/players/AlienPlayerTest.java
@@ -6,8 +6,7 @@ import com.mael.ttt.ui.UserInterface;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.mael.ttt.Mark.PLAYER;
-import static com.mael.ttt.players.PlayerType.ALIEN;
+import static com.mael.ttt.Mark.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/mael/ttt/players/HumanPlayerTest.java
+++ b/src/test/java/com/mael/ttt/players/HumanPlayerTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.mael.ttt.Mark.PLAYER;
-import static com.mael.ttt.players.PlayerType.HUMAN;
 import static org.junit.Assert.assertEquals;
 
 public class HumanPlayerTest {

--- a/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
+++ b/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
@@ -1,0 +1,47 @@
+package com.mael.ttt.players;
+
+import com.mael.ttt.ui.SpyConsole;
+import com.mael.ttt.ui.UserInterface;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.mael.ttt.ui.MenuOption.*;
+import static org.junit.Assert.assertTrue;
+
+public class PlayerCreatorTest {
+
+    private PlayerCreator playerCreator;
+    private UserInterface gameUI;
+
+    @Before
+    public void setUp() {
+        gameUI = new UserInterface(new SpyConsole());
+        playerCreator = new PlayerCreator(gameUI);
+    }
+
+    @Test
+    public void createsHumanAsPlayer() {
+        assertTrue(playerCreator.createPlayer(HUMAN_HUMAN) instanceof HumanPlayer);
+        assertTrue(playerCreator.createPlayer(HUMAN_ROBOT) instanceof HumanPlayer);
+        assertTrue(playerCreator.createPlayer(HUMAN_ALIEN) instanceof HumanPlayer);
+    }
+
+    @Test
+    public void createsHumanAsOpponent() {
+        assertTrue(playerCreator.createOpponent(HUMAN_HUMAN) instanceof HumanPlayer);
+    }
+
+    @Test
+    public void createsRobotAsPlayer() {
+        assertTrue(playerCreator.createPlayer(ROBOT_ROBOT) instanceof RobotPlayer);
+    }
+
+    @Test
+    public void createsRobotAsOpponent() {
+        assertTrue(playerCreator.createOpponent(HUMAN_ROBOT) instanceof RobotPlayer);
+    }
+
+    @Test
+    public void createsAlienAsOpponent() {
+        assertTrue(playerCreator.createOpponent(HUMAN_ALIEN) instanceof AlienPlayer);
+    }}

--- a/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
+++ b/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
@@ -15,7 +15,7 @@ public class PlayerCreatorTest {
 
     @Before
     public void setUp() {
-        gameUI = new UserInterface(new SpyConsole());
+        gameUI        = new UserInterface(new SpyConsole());
         playerCreator = new PlayerCreator(gameUI);
     }
 

--- a/src/test/java/com/mael/ttt/players/RobotPlayerTest.java
+++ b/src/test/java/com/mael/ttt/players/RobotPlayerTest.java
@@ -6,9 +6,7 @@ import com.mael.ttt.ui.UserInterface;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.mael.ttt.Mark.OPPONENT;
-import static com.mael.ttt.Mark.PLAYER;
-import static com.mael.ttt.players.PlayerType.ROBOT;
+import static com.mael.ttt.Mark.*;
 import static org.junit.Assert.assertEquals;
 
 public class RobotPlayerTest {
@@ -31,7 +29,7 @@ public class RobotPlayerTest {
 
     @Test
     public void promptMessageIsPrinted() {
-        board  =new Board(size);
+        board = new Board(size);
         robotPlayer.getMove(board);
         assertEquals(UserInterface.ROBOTPROMT, spy.firstPrintedMessage());
     }

--- a/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
@@ -1,6 +1,5 @@
 package com.mael.ttt.ui;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static com.mael.ttt.players.PlayerType.*;
@@ -8,13 +7,6 @@ import static com.mael.ttt.ui.MenuOption.*;
 import static org.junit.Assert.assertEquals;
 
 public class MenuOptionTest {
-
-    private UserInterface gameUI;
-
-    @Before
-    public void setUp() {
-        gameUI = new UserInterface(new SpyConsole());
-    }
 
     @Test
     public void getsHumanVsHumanId() {

--- a/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
@@ -3,10 +3,8 @@ package com.mael.ttt.ui;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.mael.ttt.players.PlayerType.HUMAN;
-import static com.mael.ttt.players.PlayerType.ROBOT;
-import static com.mael.ttt.ui.MenuOption.HUMAN_HUMAN;
-import static com.mael.ttt.ui.MenuOption.HUMAN_ROBOT;
+import static com.mael.ttt.players.PlayerType.*;
+import static com.mael.ttt.ui.MenuOption.*;
 import static org.junit.Assert.assertEquals;
 
 public class MenuOptionTest {

--- a/src/test/java/com/mael/ttt/ui/MenuTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuTest.java
@@ -22,4 +22,11 @@ public class MenuTest {
         menu.getUserOption();
         assertEquals(3, spy.timesReadWasCalled());
     }
+
+    @Test
+    public void printsMenuPrompt() {
+        spy.setInput("1");
+        menu.getUserOption();
+        assertEquals(UserInterface.MENUPROMPT, spy.firstPrintedMessage());
+    }
 }

--- a/src/test/java/com/mael/ttt/ui/UserInterfaceSpy.java
+++ b/src/test/java/com/mael/ttt/ui/UserInterfaceSpy.java
@@ -3,9 +3,9 @@ package com.mael.ttt.ui;
 import com.mael.ttt.Board;
 
 public class UserInterfaceSpy extends UserInterface {
-    private boolean printBoardHasBeenCalled = false;
-    private boolean printHasWinnerMessageHasBeenCalled = false;
-    private boolean printIsFullMessageHasBeenCalled = false;
+    private boolean printBoardWasCalled = false;
+    private boolean printHasWinnerMessageWasCalled = false;
+    private boolean printIsFullMessageWasCalled = false;
     private String winner = "";
 
     public UserInterfaceSpy() {
@@ -27,7 +27,7 @@ public class UserInterfaceSpy extends UserInterface {
 
     @Override
     public void printBoard(Board board) {
-        printBoardHasBeenCalled = true;
+        printBoardWasCalled = true;
     }
 
     @Override
@@ -63,12 +63,12 @@ public class UserInterfaceSpy extends UserInterface {
     @Override
     public void printHasWinnerMessage(String currentPlayer) {
         winner = currentPlayer;
-        printHasWinnerMessageHasBeenCalled = true;
+        printHasWinnerMessageWasCalled = true;
     }
 
     @Override
     public void printIsFullMessage() {
-        printIsFullMessageHasBeenCalled = true;
+        printIsFullMessageWasCalled = true;
     }
 
     @Override
@@ -76,16 +76,16 @@ public class UserInterfaceSpy extends UserInterface {
         return "";
     }
 
-    public boolean printBoardHasBeeCalled() {
-        return printBoardHasBeenCalled;
+    public boolean printBoardWasCalled() {
+        return printBoardWasCalled;
     }
 
-    public boolean printHasWinnerMessageHasBeenCalled() {
-        return printHasWinnerMessageHasBeenCalled;
+    public boolean printHasWinnerMessageWasCalled() {
+        return printHasWinnerMessageWasCalled;
     }
 
-    public boolean printIsFullMessageHasBeenCalled() {
-        return printIsFullMessageHasBeenCalled;
+    public boolean printIsFullMessageWasCalled() {
+        return printIsFullMessageWasCalled;
     }
 
     public String announcedWinner() {


### PR DESCRIPTION
This PR **extracts the player-creation logic from the game setup and puts it in its own class, `PlayerCreator`**. The class has only one reason to change (adding a new player), but is not open-closed. I still don't know what to do or think it's a bad idea that when I add a new Player class, I have to add a constant to the `PlayerType` enum and an `else if`to the player creator. Although the `PlayerType` has proved to be more convenient that using `String`s

Also, is the `MenuOption` enum now used in a more _idiomatic_ way?

@ChristophGockel: I haven't checked yet the tests that use the user interface spy, will try to do that tomorrow. @ecomba
