### PR TITLE
Choose the appropriate player/option enum:

### DIFF
--- a/src/main/java/com/mael/ttt/players/PlayerCreator.java
+++ b/src/main/java/com/mael/ttt/players/PlayerCreator.java
@@ -1,11 +1,10 @@
 package com.mael.ttt.players;
 
-import com.mael.ttt.Mark;
 import com.mael.ttt.ui.MenuOption;
 import com.mael.ttt.ui.UserInterface;
 
 import static com.mael.ttt.Mark.*;
-import static com.mael.ttt.players.PlayerType.*;
+import static com.mael.ttt.ui.MenuOption.*;
 
 public class PlayerCreator {
 
@@ -16,19 +15,26 @@ public class PlayerCreator {
     }
 
     public Player createPlayer(MenuOption option) {
-        return createPlayerOfType(option.getPlayerType(), PLAYER);
+        return createPlayerOfType(option);
     }
 
     public Player createOpponent(MenuOption option) {
-        return createPlayerOfType(option.getOpponentType(), OPPONENT);
+        return createOpponentOfType(option);
     }
 
-    private Player createPlayerOfType(PlayerType playerType, Mark mark) {
-        if (playerType == ROBOT) {
-            return new RobotPlayer(gameUI, mark);
-        } else if (playerType == ALIEN) {
-            return new AlienPlayer(gameUI, mark);
+    private Player createPlayerOfType(MenuOption option) {
+        if (option == ROBOT_ROBOT) {
+            return new RobotPlayer(gameUI, PLAYER);
         }
-        return new HumanPlayer(gameUI, mark);
+        return new HumanPlayer(gameUI, PLAYER);
+    }
+
+    private Player createOpponentOfType(MenuOption option) {
+        if (option == HUMAN_ROBOT || option == ROBOT_ROBOT) {
+            return new RobotPlayer(gameUI, OPPONENT);
+        } else if (option == HUMAN_ALIEN) {
+            return new AlienPlayer(gameUI, OPPONENT);
+        }
+        return new HumanPlayer(gameUI, OPPONENT);
     }
 }

--- a/src/main/java/com/mael/ttt/players/PlayerCreator.java
+++ b/src/main/java/com/mael/ttt/players/PlayerCreator.java
@@ -15,21 +15,13 @@ public class PlayerCreator {
     }
 
     public Player createPlayer(MenuOption option) {
-        return createPlayerOfType(option);
-    }
-
-    public Player createOpponent(MenuOption option) {
-        return createOpponentOfType(option);
-    }
-
-    private Player createPlayerOfType(MenuOption option) {
         if (option == ROBOT_ROBOT) {
             return new RobotPlayer(gameUI, PLAYER);
         }
         return new HumanPlayer(gameUI, PLAYER);
     }
 
-    private Player createOpponentOfType(MenuOption option) {
+    public Player createOpponent(MenuOption option) {
         if (option == HUMAN_ROBOT || option == ROBOT_ROBOT) {
             return new RobotPlayer(gameUI, OPPONENT);
         } else if (option == HUMAN_ALIEN) {

--- a/src/main/java/com/mael/ttt/players/PlayerType.java
+++ b/src/main/java/com/mael/ttt/players/PlayerType.java
@@ -1,5 +1,0 @@
-package com.mael.ttt.players;
-
-public enum PlayerType {
-    ALIEN, HUMAN, ROBOT
-}

--- a/src/main/java/com/mael/ttt/ui/MenuOption.java
+++ b/src/main/java/com/mael/ttt/ui/MenuOption.java
@@ -1,25 +1,17 @@
 package com.mael.ttt.ui;
 
-import com.mael.ttt.players.PlayerType;
-
-import static com.mael.ttt.players.PlayerType.*;
-
 public enum MenuOption {
-    HUMAN_HUMAN("1", "Human vs. Human", HUMAN, HUMAN),
-    HUMAN_ROBOT("2", "Human vs. Robot", HUMAN, ROBOT),
-    ROBOT_ROBOT("3", "Robot vs. Robot", ROBOT, ROBOT),
-    HUMAN_ALIEN("4", "Human vs. Alien", HUMAN, ALIEN);
+    HUMAN_HUMAN("1", "Human vs. Human"),
+    HUMAN_ROBOT("2", "Human vs. Robot"),
+    ROBOT_ROBOT("3", "Robot vs. Robot"),
+    HUMAN_ALIEN("4", "Human vs. Alien");
 
     private String menuOptionId;
     private String menuOptionText;
-    private PlayerType playerType;
-    private PlayerType opponentType;
 
-    MenuOption(String menuOptionId, String menuOptionText, PlayerType player, PlayerType opponent) {
+    MenuOption(String menuOptionId, String menuOptionText) {
         this.menuOptionId   = menuOptionId;
         this.menuOptionText = menuOptionText;
-        this.playerType     = player;
-        this.opponentType   = opponent;
     }
 
     public String getMenuOptionId() {
@@ -30,13 +22,6 @@ public enum MenuOption {
         return menuOptionText;
     }
 
-    public PlayerType getPlayerType() {
-        return playerType;
-    }
-
-    public PlayerType getOpponentType() {
-        return opponentType;
-    }
 
     public static MenuOption idToOption(String menuOptionId) {
         for (MenuOption menuOption : values()) {

--- a/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
+++ b/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
@@ -27,21 +27,23 @@ public class PlayerCreatorTest {
     }
 
     @Test
-    public void createsHumanAsOpponent() {
-        assertTrue(playerCreator.createOpponent(HUMAN_HUMAN) instanceof HumanPlayer);
-    }
-
-    @Test
     public void createsRobotAsPlayer() {
         assertTrue(playerCreator.createPlayer(ROBOT_ROBOT) instanceof RobotPlayer);
     }
 
     @Test
+    public void createsHumanAsOpponent() {
+        assertTrue(playerCreator.createOpponent(HUMAN_HUMAN) instanceof HumanPlayer);
+    }
+
+    @Test
     public void createsRobotAsOpponent() {
         assertTrue(playerCreator.createOpponent(HUMAN_ROBOT) instanceof RobotPlayer);
+        assertTrue(playerCreator.createOpponent(ROBOT_ROBOT) instanceof RobotPlayer);
     }
 
     @Test
     public void createsAlienAsOpponent() {
         assertTrue(playerCreator.createOpponent(HUMAN_ALIEN) instanceof AlienPlayer);
-    }}
+    }
+}

--- a/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
@@ -2,7 +2,6 @@ package com.mael.ttt.ui;
 
 import org.junit.Test;
 
-import static com.mael.ttt.players.PlayerType.*;
 import static com.mael.ttt.ui.MenuOption.*;
 import static org.junit.Assert.assertEquals;
 
@@ -16,16 +15,6 @@ public class MenuOptionTest {
     @Test
     public void getsHumanVsHumanText() {
         assertEquals("Human vs. Human", HUMAN_HUMAN.getMenuOptionText());
-    }
-
-    @Test
-    public void getsPlayerType() {
-        assertEquals(HUMAN, HUMAN_ROBOT.getPlayerType());
-    }
-
-    @Test
-    public void getsOpponentType() {
-        assertEquals(ROBOT, HUMAN_ROBOT.getOpponentType());
     }
 
     @Test


### PR DESCRIPTION
I made this PR to:
- Delete the player type enum.
- Remove the two constructor parameters in the menuOption enum and their getters.
- Replace the use of the player type enum with the menuOption enum in the player creator class
- Add a new method in the player creator to create an opponent of a certain type.

I don't really like that there are now two methods to create a player of a certain type, player or opponent, I feel like I just moved the duplication from the `playerType` enum to the `PlayerCreator` class. However, now I have to change things in just one place. And I want to keep the returning of the players in a different method, I want to avoid to return a list.

I left the methods return a human player by default, since the methods take an enum and only an existing one can be passed. However, I tried a test for an inexisting menu option but I didn't get very far and couldn't make it work. It also seemed like an unnecessary overkill:

``` java
    @Test
    public void createsHumanAsPlayerIfInvalidMenuOption() {
        assertTrue(playerCreator.createPlayer(MenuOption.valueOf("INEXISTING_ENUM")) instanceof HumanPlayer);
    }
```

@ChristophGockel, @ecomba, I think the apprentices could be interested to know what's the best approach here? Although we almost concluded that there was no need to test it.
