### PR TITLE
Move option validation

### DIFF
--- a/src/main/java/com/mael/ttt/GameRunner.java
+++ b/src/main/java/com/mael/ttt/GameRunner.java
@@ -1,13 +1,17 @@
 
 package com.mael.ttt;
 
+import com.mael.ttt.players.PlayerCreator;
 import com.mael.ttt.ui.GameConsole;
+import com.mael.ttt.ui.Menu;
 import com.mael.ttt.ui.UserInterface;
 
 public class GameRunner {
 
     public static void main(String[] args) {
-        GameSetup gameSetup = new GameSetup(new Board(3), new UserInterface(new GameConsole(System.in, System.out)));
+        UserInterface gameUI = new UserInterface(new GameConsole(System.in, System.out));
+        Board board          = new Board(3);
+        GameSetup gameSetup  = new GameSetup(gameUI, new Menu(gameUI), board, new Turn(board, new BoardChecker(board), gameUI), new PlayerCreator(gameUI));
         gameSetup.playGame();
     }
 }

--- a/src/main/java/com/mael/ttt/GameSetup.java
+++ b/src/main/java/com/mael/ttt/GameSetup.java
@@ -6,21 +6,25 @@ import com.mael.ttt.ui.MenuOption;
 import com.mael.ttt.ui.UserInterface;
 
 public class GameSetup {
-    private Board board;
-    private BoardChecker checker;
     private UserInterface gameUI;
+    private Menu menu;
+    private Board board;
+    private Turn turn;
+    private PlayerCreator playerCreator;
 
-    public GameSetup(Board board, UserInterface gameUI) {
-        this.board   = board;
-        this.checker = new BoardChecker(board);
-        this.gameUI  = gameUI;
+    public GameSetup(UserInterface gameUI, Menu menu, Board board, Turn turn, PlayerCreator playerCreator) {
+        this.gameUI        = gameUI;
+        this.menu          = menu;
+        this.board         = board;
+        this.turn          = turn;
+        this.playerCreator = playerCreator;
     }
 
     public void playGame() {
         do {
             setUp();
-            MenuOption option = getMenuOption();
-            Game game         = new Game(new Turn(board, checker, gameUI), createPlayer(option), createOpponent(option));
+            MenuOption option = menu.getUserOption();
+            Game game         = new Game(turn, playerCreator.createPlayer(option), playerCreator.createOpponent(option));
             game.play();
         } while (gameUI.replay());
     }
@@ -28,17 +32,5 @@ public class GameSetup {
     private void setUp() {
         board.reset();
         gameUI.printWelcomeMessage();
-    }
-
-    private MenuOption getMenuOption() {
-        return new Menu(gameUI).getUserOption();
-    }
-
-    private Player createPlayer(MenuOption option) {
-        return new PlayerCreator(gameUI).createPlayer(option);
-    }
-
-    private Player createOpponent(MenuOption option) {
-        return new PlayerCreator(gameUI).createOpponent(option);
     }
 }

--- a/src/main/java/com/mael/ttt/ui/Menu.java
+++ b/src/main/java/com/mael/ttt/ui/Menu.java
@@ -1,16 +1,11 @@
 package com.mael.ttt.ui;
 
-import java.util.*;
-
 public class Menu {
 
     private UserInterface gameUI;
-    private List<String> menuOptionIds;
 
     public Menu(UserInterface gameUI) {
-        this.gameUI        = gameUI;
-        this.menuOptionIds = new ArrayList<>();
-        initializeOptions();
+        this.gameUI = gameUI;
     }
 
     public MenuOption getUserOption() {
@@ -24,12 +19,6 @@ public class Menu {
     }
 
     private boolean isInvalidOption(String option) {
-        return !menuOptionIds.contains(option);
-    }
-
-    private void initializeOptions() {
-        for (MenuOption menuOption : MenuOption.values()) {
-            this.menuOptionIds.add(menuOption.getMenuOptionId());
-        }
+        return !MenuOption.contains(option);
     }
 }

--- a/src/main/java/com/mael/ttt/ui/MenuOption.java
+++ b/src/main/java/com/mael/ttt/ui/MenuOption.java
@@ -24,7 +24,7 @@ public enum MenuOption {
 
     public static MenuOption idToOption(String id) {
         for (MenuOption menuOption : values()) {
-            if (id.equals(menuOption.getMenuOptionId())) {
+            if (id != null && id.equals(menuOption.getMenuOptionId())) {
                 return menuOption;
             }
         }
@@ -33,7 +33,7 @@ public enum MenuOption {
 
     public static boolean contains(String id) {
         for (MenuOption menuOption : values()) {
-            if (id.equals(menuOption.getMenuOptionId())) {
+            if (id != null && id.equals(menuOption.getMenuOptionId())) {
                 return true;
             }
         }

--- a/src/main/java/com/mael/ttt/ui/MenuOption.java
+++ b/src/main/java/com/mael/ttt/ui/MenuOption.java
@@ -28,7 +28,15 @@ public enum MenuOption {
                 return menuOption;
             }
         }
-
         return HUMAN_HUMAN;
+    }
+
+    public static boolean contains(String id) {
+        for (MenuOption menuOption : values()) {
+            if (id.equals(menuOption.getMenuOptionId())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/mael/ttt/ui/MenuOption.java
+++ b/src/main/java/com/mael/ttt/ui/MenuOption.java
@@ -22,10 +22,9 @@ public enum MenuOption {
         return menuOptionText;
     }
 
-
-    public static MenuOption idToOption(String menuOptionId) {
+    public static MenuOption idToOption(String id) {
         for (MenuOption menuOption : values()) {
-            if (menuOptionId.equals(menuOption.getMenuOptionId())) {
+            if (id.equals(menuOption.getMenuOptionId())) {
                 return menuOption;
             }
         }

--- a/src/test/java/com/mael/ttt/GameSetupTest.java
+++ b/src/test/java/com/mael/ttt/GameSetupTest.java
@@ -1,49 +1,43 @@
 package com.mael.ttt;
 
 import com.mael.ttt.players.PlayerCreator;
-import com.mael.ttt.ui.SpyConsole;
-import com.mael.ttt.ui.UserInterface;
+import com.mael.ttt.ui.UserInterfaceSpy;
 import org.junit.Before;
 import org.junit.Test;
 import com.mael.ttt.ui.Menu;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GameSetupTest {
 
     private int size;
-    private SpyConsole spy;
-    private GameSetup gameSetup;
-    private UserInterface gameUI;
     private Board board;
+    private UserInterfaceSpy uiSpy;
+    private GameSetup gameSetup;
 
     @Before
     public void setUp() {
         size      = 3;
-        spy       = new SpyConsole();
-        gameUI    = new UserInterface(spy);
         board     = new Board(size);
-        gameSetup = new GameSetup(gameUI, new Menu(gameUI), board, new Turn(board, new BoardChecker(board), gameUI), new PlayerCreator(gameUI));
+        uiSpy     = new UserInterfaceSpy();
+        gameSetup = new GameSetup(uiSpy, new Menu(uiSpy), board, new Turn(board, new BoardChecker(board), uiSpy), new PlayerCreator(uiSpy));
+        uiSpy.setMenuOption("1");
     }
 
     @Test
     public void printsWelcomeMessage() {
-        spy.setInputs("1",
-                      "1", "4", "2", "5", "3",
-                      "n");
+        uiSpy.setUserInputs(1, 4, 2, 5, 3);
+        uiSpy.setReplayAnswers(false);
         gameSetup.playGame();
-        assertEquals(UserInterface.WELCOME, spy.firstPrintedMessage());
+        assertTrue(uiSpy.printWelcomeMessageWasCalled());
     }
 
     @Test
     public void replaysUntilNo() {
-        spy.setInputs("1",
-                      "1", "4", "2", "5", "3",
-                      "y",
-                      "1",
-                      "1", "2", "3", "4", "5", "7", "6", "9", "8",
-                      "n");
+        uiSpy.setUserInputs(1, 4, 2, 5, 3,
+                            1, 2, 3, 4, 5, 7, 6, 9, 8);
+        uiSpy.setReplayAnswers(true, false);
         gameSetup.playGame();
-        assertEquals(UserInterface.REPLAY, spy.lastPrintedMessage());
+        assertTrue(uiSpy.replayWasCalled());
     }
 }

--- a/src/test/java/com/mael/ttt/GameSetupTest.java
+++ b/src/test/java/com/mael/ttt/GameSetupTest.java
@@ -1,9 +1,11 @@
 package com.mael.ttt;
 
+import com.mael.ttt.players.PlayerCreator;
 import com.mael.ttt.ui.SpyConsole;
 import com.mael.ttt.ui.UserInterface;
 import org.junit.Before;
 import org.junit.Test;
+import com.mael.ttt.ui.Menu;
 
 import static org.junit.Assert.assertEquals;
 
@@ -12,12 +14,16 @@ public class GameSetupTest {
     private int size;
     private SpyConsole spy;
     private GameSetup gameSetup;
+    private UserInterface gameUI;
+    private Board board;
 
     @Before
     public void setUp() {
         size      = 3;
         spy       = new SpyConsole();
-        gameSetup = new GameSetup(new Board(size), new UserInterface(spy));
+        gameUI    = new UserInterface(spy);
+        board     = new Board(size);
+        gameSetup = new GameSetup(gameUI, new Menu(gameUI), board, new Turn(board, new BoardChecker(board), gameUI), new PlayerCreator(gameUI));
     }
 
     @Test

--- a/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
+++ b/src/test/java/com/mael/ttt/players/PlayerCreatorTest.java
@@ -46,4 +46,10 @@ public class PlayerCreatorTest {
     public void createsAlienAsOpponent() {
         assertTrue(playerCreator.createOpponent(HUMAN_ALIEN) instanceof AlienPlayer);
     }
+
+    @Test
+    public void returnsHumanIfNullMenuOptionIsPassed() {
+        assertTrue(playerCreator.createPlayer(null)   instanceof HumanPlayer);
+        assertTrue(playerCreator.createOpponent(null) instanceof HumanPlayer);
+    }
 }

--- a/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
@@ -21,12 +21,17 @@ public class MenuOptionTest {
 
     @Test
     public void returnsMenuOptionGivenAnId() {
-        assertEquals(HUMAN_ROBOT, MenuOption.idToOption("2"));
+        assertEquals(HUMAN_HUMAN, MenuOption.idToOption("1"));
     }
 
     @Test
     public void returnsHumanVsHumanIfInvalidOption() {
         assertEquals(HUMAN_HUMAN, MenuOption.idToOption("asdfg"));
+    }
+
+    @Test
+    public void returnsHumanVsHumanIfNullOption() {
+        assertEquals(HUMAN_HUMAN, MenuOption.idToOption(null));
     }
 
     @Test
@@ -37,5 +42,9 @@ public class MenuOptionTest {
     @Test
     public void returnsFalseIfUnexistingIdInEnumConstants() {
         assertFalse(MenuOption.contains("asdf"));
+    }
+    @Test
+    public void returnsFalseIfNullOption() {
+        assertFalse(MenuOption.contains(null));
     }
 }

--- a/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
+++ b/src/test/java/com/mael/ttt/ui/MenuOptionTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import static com.mael.ttt.ui.MenuOption.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MenuOptionTest {
 
@@ -25,5 +27,15 @@ public class MenuOptionTest {
     @Test
     public void returnsHumanVsHumanIfInvalidOption() {
         assertEquals(HUMAN_HUMAN, MenuOption.idToOption("asdfg"));
+    }
+
+    @Test
+    public void returnsTrueIfIdExistsInEnumConstants() {
+        assertTrue(MenuOption.contains("1"));
+    }
+
+    @Test
+    public void returnsFalseIfUnexistingIdInEnumConstants() {
+        assertFalse(MenuOption.contains("asdf"));
     }
 }

--- a/src/test/java/com/mael/ttt/ui/UserInterfaceSpy.java
+++ b/src/test/java/com/mael/ttt/ui/UserInterfaceSpy.java
@@ -2,11 +2,20 @@ package com.mael.ttt.ui;
 
 import com.mael.ttt.Board;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class UserInterfaceSpy extends UserInterface {
     private boolean printBoardWasCalled = false;
     private boolean printHasWinnerMessageWasCalled = false;
     private boolean printIsFullMessageWasCalled = false;
     private String winner = "";
+    private boolean printWelcomeMessageWasCalled = false;
+    private List<Integer> userInputs = new ArrayList<>();
+    private String menuOption = "";
+    private boolean replayWasCalled = false;
+    private List<Boolean> replayAnswers = new ArrayList<>();
 
     public UserInterfaceSpy() {
         super(null);
@@ -32,16 +41,17 @@ public class UserInterfaceSpy extends UserInterface {
 
     @Override
     public void printWelcomeMessage() {
+        printWelcomeMessageWasCalled = true;
     }
 
     @Override
     public String getMenuOption(String menu) {
-        return "";
+        return menuOption;
     }
 
     @Override
     public String getInput() {
-        return "1";
+        return userInputs.remove(0).toString();
     }
 
     @Override
@@ -73,7 +83,8 @@ public class UserInterfaceSpy extends UserInterface {
 
     @Override
     public boolean replay() {
-        return false;
+        replayWasCalled = true;
+        return replayAnswers.remove(0);
     }
 
     public boolean printBoardWasCalled() {
@@ -88,7 +99,27 @@ public class UserInterfaceSpy extends UserInterface {
         return printIsFullMessageWasCalled;
     }
 
+    public boolean printWelcomeMessageWasCalled() {
+        return printWelcomeMessageWasCalled;
+    }
+
     public String announcedWinner() {
         return winner;
+    }
+
+    public void setReplayAnswers(Boolean ... replayAnswers) {
+        this.replayAnswers.addAll(Arrays.asList(replayAnswers));
+    }
+
+    public void setUserInputs(Integer ... userInputs) {
+        this.userInputs.addAll(Arrays.asList(userInputs));
+    }
+
+    public void setMenuOption (String menuOption) {
+        this.menuOption = menuOption;
+    }
+
+    public boolean replayWasCalled() {
+        return replayWasCalled;
     }
 }


### PR DESCRIPTION
@ChristophGockel, @ecomba, this PR moves the menu option validation to the `MenuOption` enum (the new `contains()` method), injects all dependencies in the Game Setup class, and updates the game setup tests so that they use the user interface spy, for which I also had to update the spy itself. Not happy passing five parameters in the constructor, I'll have to think of a better way of doing this.

I also added the corrections from the previous PR, and added more tests and checks for nulls in the `MenuOption` enum and the `PlayerCreator` class. As a result, I now have an ugly `if (id != null && ...`, for the input coming from the user. Gotta think how to get rid of that too.
