### PR TITLE
Prepare the board class for a 4x4 board

### DIFF
--- a/src/main/java/com/mael/ttt/Board.java
+++ b/src/main/java/com/mael/ttt/Board.java
@@ -23,6 +23,13 @@ public class Board {
         }
     }
 
+    public Board(Mark ... cellContents) {
+        this((int) Math.sqrt(cellContents.length));
+        for (int index = 1; index <= SIZE*SIZE; index++) {
+            setCell(index, cellContents[index - 1]);
+        }
+    }
+
     public int getSize() {
         return SIZE;
     }
@@ -71,13 +78,5 @@ public class Board {
 
     public boolean isCellBusy(int index) {
         return !(board[getRowFromIndex(index)][getColFromIndex(index)] == EMPTY);
-    }
-
-    public void setBoardContents(Mark ... cellContents) {
-        if (cellContents.length == SIZE*SIZE) {
-            for (int index = 1; index <= SIZE*SIZE; index++) {
-                setCell(index, cellContents[index - 1]);
-            }
-        }
     }
 }

--- a/src/main/java/com/mael/ttt/Board.java
+++ b/src/main/java/com/mael/ttt/Board.java
@@ -54,13 +54,11 @@ public class Board {
 
     public List<Integer> getEmptyCellIndexes() {
         List<Integer> empties = new ArrayList<>();
-
         for (int index = 1; index <= SIZE*SIZE; index++) {
             if (getCell(index) == EMPTY) {
                 empties.add(index);
             }
         }
-
         return empties;
     }
 

--- a/src/test/java/com/mael/ttt/BoardCheckerTest.java
+++ b/src/test/java/com/mael/ttt/BoardCheckerTest.java
@@ -1,24 +1,32 @@
 package com.mael.ttt;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static com.mael.ttt.Mark.*;
 
+@RunWith(Parameterized.class)
 public class BoardCheckerTest {
 
     private int size;
     private Board board;
     private BoardChecker checker;
 
-    @Before
-    public void setUp() {
-        size    = 3;
+    public BoardCheckerTest(int boardSize) {
+        size    = boardSize;
         board   = new Board(size);
         checker = new BoardChecker(board);
+    }
 
+    @Parameterized.Parameters
+    public static Collection dataSetup() {
+        return Arrays.asList(new Object[][]{ {3}, {4} });
     }
 
     @Test

--- a/src/test/java/com/mael/ttt/BoardCheckerTest.java
+++ b/src/test/java/com/mael/ttt/BoardCheckerTest.java
@@ -9,11 +9,9 @@ import static com.mael.ttt.Mark.*;
 
 public class BoardCheckerTest {
 
-    int size;
+    private int size;
     private Board board;
     private BoardChecker checker;
-    private Mark playerMark;
-    private Mark opponentMark;
 
     @Before
     public void setUp() {
@@ -21,8 +19,6 @@ public class BoardCheckerTest {
         board   = new Board(size);
         checker = new BoardChecker(board);
 
-        playerMark   = PLAYER;
-        opponentMark = OPPONENT;
     }
 
     @Test
@@ -33,41 +29,41 @@ public class BoardCheckerTest {
 
     @Test
     public void thereIsNoWinnerIfEmptyBoard() {
-        assertFalse(checker.hasWinner(playerMark));
-        assertFalse(checker.hasWinner(opponentMark));
+        assertFalse(checker.hasWinner(PLAYER));
+        assertFalse(checker.hasWinner(OPPONENT));
     }
 
     @Test
     public void checksWinnerInRow() {
-        setBoardContents(size, playerMark);
-        assertTrue(checker.hasWinner(playerMark));
+        setBoardContents(size, PLAYER);
+        assertTrue(checker.hasWinner(PLAYER));
     }
 
     @Test
     public void checksWinnerInColumn() {
         for (int row = 0; row < size; row++) {
-            board.setCell(board.getIndexFromCoords(row, 0), playerMark);
+            board.setCell(board.getIndexFromCoords(row, 0), PLAYER);
         }
 
-        assertTrue(checker.hasWinner(playerMark));
+        assertTrue(checker.hasWinner(PLAYER));
     }
 
     @Test
     public void checksWinnerInDiagonal() {
         for (int row = 0, col = 0; row < size && col < size; row++, col++) {
-            board.setCell(board.getIndexFromCoords(row, col), playerMark);
+            board.setCell(board.getIndexFromCoords(row, col), PLAYER);
         }
 
-        assertTrue(checker.hasWinner(playerMark));
+        assertTrue(checker.hasWinner(PLAYER));
     }
 
     @Test
     public void checksWinnerInAntiDiagonal() {
         for (int row = 0, col = size-1; row < size && col >= 0; row++, col--) {
-            board.setCell(board.getIndexFromCoords(row, col), playerMark);
+            board.setCell(board.getIndexFromCoords(row, col), PLAYER);
         }
 
-        assertTrue(checker.hasWinner(playerMark));
+        assertTrue(checker.hasWinner(PLAYER));
     }
 
     private void setBoardContents(int numberOfCells, Mark cellContent) {

--- a/src/test/java/com/mael/ttt/BoardTest.java
+++ b/src/test/java/com/mael/ttt/BoardTest.java
@@ -1,23 +1,31 @@
 package com.mael.ttt;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static com.mael.ttt.Mark.*;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
+@RunWith(Parameterized.class)
 public class BoardTest {
 
     private int size;
     private Board board;
 
-    @Before
-    public void setUp() {
-        size  = 3;
+    public BoardTest(int boardSize) {
+        size  = boardSize;
         board = new Board(size);
+    }
+
+    @Parameterized.Parameters
+    public static Collection dataSetup() {
+        return Arrays.asList(new Object[][] { {3}, {4} });
     }
 
     @Test
@@ -39,7 +47,7 @@ public class BoardTest {
     @Test
     public void getsTheEmptyCellIndexes() {
         board.setCell(1, PLAYER);
-        List<Integer> expected = asList(2, 3, 4, 5, 6, 7, 8, 9);
+        List<Integer> expected = getAllIndexesStartingOn(2);
         assertEquals(expected, board.getEmptyCellIndexes());
     }
 
@@ -83,5 +91,13 @@ public class BoardTest {
             boardContents += board.getCell(index).getString();
         }
         return boardContents;
+    }
+
+    private List<Integer> getAllIndexesStartingOn(int start) {
+        List<Integer> expected = new ArrayList<>();
+        for (int i = start; i <= size*size; i++) {
+            expected.add(i);
+        }
+        return expected;
     }
 }

--- a/src/test/java/com/mael/ttt/BoardTest.java
+++ b/src/test/java/com/mael/ttt/BoardTest.java
@@ -47,7 +47,7 @@ public class BoardTest {
     @Test
     public void getsTheEmptyCellIndexes() {
         board.setCell(1, PLAYER);
-        List<Integer> expected = getAllIndexesStartingOn(2);
+        List<Integer> expected = getCellIndexesStartingOn(2);
         assertEquals(expected, board.getEmptyCellIndexes());
     }
 
@@ -93,7 +93,7 @@ public class BoardTest {
         return boardContents;
     }
 
-    private List<Integer> getAllIndexesStartingOn(int start) {
+    private List<Integer> getCellIndexesStartingOn(int start) {
         List<Integer> expected = new ArrayList<>();
         for (int i = start; i <= size*size; i++) {
             expected.add(i);

--- a/src/test/java/com/mael/ttt/BoardTest.java
+++ b/src/test/java/com/mael/ttt/BoardTest.java
@@ -69,13 +69,6 @@ public class BoardTest {
         assertTrue(board.isCellBusy(1));
     }
 
-    @Test
-    public void setsAllBoardContentsAtOnce() {
-        Board expected = setAllCellsTo(PLAYER);
-        board.setBoardContents(PLAYER, PLAYER, PLAYER, PLAYER, PLAYER, PLAYER, PLAYER, PLAYER, PLAYER);
-        assertEquals(getContentsAsString(expected), getContentsAsString(board));
-    }
-
     private Board setAllCellsTo(Mark cellContent) {
         Board expected = new Board(size);
         for (int index = 1; index <= size*size; index++) {

--- a/src/test/java/com/mael/ttt/TurnTest.java
+++ b/src/test/java/com/mael/ttt/TurnTest.java
@@ -22,8 +22,8 @@ public class TurnTest {
         size   = 3;
         board  = new Board(size);
         uiSpy  = new UserInterfaceSpy();
-        turn   = new Turn(board, new BoardChecker(board), uiSpy);
         player = new FakePlayer(1);
+        turn   = new Turn(board, new BoardChecker(board), uiSpy);
         X      = PLAYER;
         O      = OPPONENT;
         E      = EMPTY;
@@ -49,65 +49,70 @@ public class TurnTest {
 
     @Test
     public void cannotBePlayedIfBoardHasWinner() {
-        board.setBoardContents(X, X, X,
-                               O, O, E,
-                               E, E, E);
+        board = new Board(X, X, X,
+                          O, O, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         assertFalse(turn.canBePlayed());
     }
 
     @Test
     public void cannotBePlayedIfBoardIsFull() {
-        board.setBoardContents(X, O, X,
-                               O, X, X,
-                               O, X, O);
+        board = new Board(X, O, X,
+                          O, X, X,
+                          O, X, O);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         assertFalse(turn.canBePlayed());
     }
 
     @Test
     public void printsBoardIfBoardHasWinner() {
-        board.setBoardContents(X, X, X,
-                               O, O, E,
-                               E, E, E);
+        board = new Board(X, X, X,
+                          O, O, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertTrue(uiSpy.printBoardWasCalled());
     }
 
     @Test
     public void printsBoardIfBoardIsFull() {
-        board.setBoardContents(X, O, X,
-                               O, X, X,
-                               O, X, O);
+        board = new Board(X, O, X,
+                          O, X, X,
+                          O, X, O);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertTrue(uiSpy.printBoardWasCalled());
     }
 
     @Test
     public void printsWinningMessageIfBoardHasWinner() {
-        board.setBoardContents(X, X, X,
-                               O, O, E,
-                               E, E, E);
+        board = new Board(X, X, X,
+                          O, O, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertTrue(uiSpy.printHasWinnerMessageWasCalled());
         assertFalse(uiSpy.printIsFullMessageWasCalled());
-
     }
 
     @Test
     public void printsFullMessageIfBoardIsFull() {
-        board.setBoardContents(X, O, X,
-                               O, X, X,
-                               O, X, O);
+        board = new Board(X, O, X,
+                          O, X, X,
+                          O, X, O);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertTrue(uiSpy.printIsFullMessageWasCalled());
         assertFalse(uiSpy.printHasWinnerMessageWasCalled());
-
     }
 
     @Test
     public void ifNoWinnerAndBoardIsNotFullJustPrintsTheBoard() {
-        board.setBoardContents(X, X, E,
-                               O, O, E,
-                               E, E, E);
+        board = new Board(X, X, E,
+                          O, O, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertTrue(uiSpy.printBoardWasCalled());
         assertFalse(uiSpy.printHasWinnerMessageWasCalled());
@@ -116,9 +121,10 @@ public class TurnTest {
 
     @Test
     public void announcesTheCorrectWinnerForPlayer() {
-        board.setBoardContents(X, X, X,
-                               O, O, E,
-                               E, E, E);
+        board = new Board(X, X, X,
+                          O, O, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(PLAYER);
         assertEquals(PLAYER, uiSpy.announcedWinner());
     }
@@ -126,11 +132,11 @@ public class TurnTest {
 
     @Test
     public void announcesTheCorrectWinnerForOpponent() {
-        board.setBoardContents(O, O, O,
-                               X, X, E,
-                               E, E, E);
+        board = new Board(O, O, O,
+                          X, X, E,
+                          E, E, E);
+        turn  = new Turn(board, new BoardChecker(board), uiSpy);
         turn.printResults(OPPONENT);
         assertEquals(OPPONENT, uiSpy.announcedWinner());
     }
-
 }

--- a/src/test/java/com/mael/ttt/players/RobotPlayerTest.java
+++ b/src/test/java/com/mael/ttt/players/RobotPlayerTest.java
@@ -38,65 +38,65 @@ public class RobotPlayerTest {
 
     @Test
     public void choosesWinningCombinationInARow() {
-        board.setBoardContents(O, O, E,
-                               X, X, E,
-                               E, E, E);
+        board = new Board(O, O, E,
+                          X, X, E,
+                          E, E, E);
         assertEquals(3, robotPlayer.getMove(board));
     }
 
     @Test
     public void choosesWinningCombinationInAColumn() {
-        board.setBoardContents(O, X, E,
-                               O, X, E,
-                               E, E, E);
+        board = new Board(O, X, E,
+                          O, X, E,
+                          E, E, E);
         assertEquals(7, robotPlayer.getMove(board));
     }
 
     @Test
     public void choosesWinningCombinationInDiagonal() {
-        board.setBoardContents(O, X, X,
-                               X, O, E,
-                               E, E, E);
+        board = new Board(O, X, X,
+                          X, O, E,
+                          E, E, E);
         assertEquals(9, robotPlayer.getMove(board));
     }
 
     @Test
     public void choosesWinningCombinationInAntiDiagonal() {
-        board.setBoardContents(X, X, O,
-                               E, O, X,
-                               E, E, E);
+        board = new Board(X, X, O,
+                          E, O, X,
+                          E, E, E);
         assertEquals(7, robotPlayer.getMove(board));
     }
 
     @Test
     public void blocksTheOpponentInARow() {
-        board.setBoardContents(X, X, E,
-                               E, O, E,
-                               E, E, E);
+        board = new Board(X, X, E,
+                          E, O, E,
+                          E, E, E);
         assertEquals(3, robotPlayer.getMove(board));
     }
 
     @Test
     public void blocksTheOpponentInAColumn() {
-        board.setBoardContents(E, E, X,
-                               E, O, E,
-                               E, E, X);
+        board = new Board(E, E, X,
+                          E, O, E,
+                          E, E, X);
         assertEquals(6, robotPlayer.getMove(board));
     }
 
     @Test
     public void blocksTheOpponentInDiagonal() {
-        board.setBoardContents(X, E, E,
-                               E, X, E,
-                               O, E, E);
+        board = new Board(X, E, E,
+                          E, X, E,
+                          O, E, E);
         assertEquals(9, robotPlayer.getMove(board));
     }
 
     @Test
     public void blocksTheOpponentInAntiDiagonal() {
-        board.setBoardContents(E, E, X,
-                               O, E, E,
-                               X, E, E);
+        board = new Board(E, E, X,
+                          O, E, E,
+                          X, E, E);
         assertEquals(5, robotPlayer.getMove(board));
     }
 


### PR DESCRIPTION
This PR takes a method that was added to the board just so that it could be used by several tests, and turns it into another constructor. It allows to set all the board contents at once using a var array.

It also does a bit of cleaning in the code and updates the tests affected by the previous change.

Finally, I decided to use the `@RunWith(Parameterized.class)` annotation in the test classes that need a board, so that I can check that all the tests work no matter the size of the board. As a result of this, I had to generalize the test for the method that obtains the empty-cell indexes:

``` java
     @Test
     public void getsTheEmptyCellIndexes() {
         board.setCell(1, PLAYER);
         List<Integer> expected = asList(2, 3, 4, 5, 6, 7, 8, 9);
         assertEquals(expected, board.getEmptyCellIndexes());
     }
```

is now 

``` java
     @Test
     public void getsTheEmptyCellIndexes() {
         board.setCell(1, PLAYER);
         List<Integer> expected = getCellIndexesStartingOn(2);
         assertEquals(expected, board.getEmptyCellIndexes());
     }
```

@ChristophGockel, @ecomba
